### PR TITLE
Allows the application to not install solr_wrapper

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,8 @@ require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
 
-require 'solr_wrapper/rake_task'
+begin
+  require 'solr_wrapper/rake_task'
+rescue LoadError
+  puts 'solr_wrapper is not installed!'
+end


### PR DESCRIPTION
This is necessary for the production environment, as solr_wrapper is a dev/test only gem.