### PR TITLE
switch facet from keyword_sim to tags_sim to correctly populate tag cloud

### DIFF
--- a/app/views/sufia/homepage/_search_by_tags.html.erb
+++ b/app/views/sufia/homepage/_search_by_tags.html.erb
@@ -1,5 +1,5 @@
 <h2>Search by Tags</h2>
 <div id="cloud-tag-container"></div>
 <div id="tag-panel" class="panel-group">
-  <%= render_facet_partials ["keyword_sim"], partial: 'facet_limit' %>
+  <%= render_facet_partials ["tags_sim"], partial: 'facet_limit' %>
 </div>


### PR DESCRIPTION
![screen shot 2016-09-12 at 3 56 25 pm](https://cloud.githubusercontent.com/assets/1202435/18450558/930bcd04-7901-11e6-80be-954516f7d9f8.png)
