### PR TITLE
remove "My" from controlled vocabs menu.

### DIFF
--- a/app/views/_toolbar.html.erb
+++ b/app/views/_toolbar.html.erb
@@ -59,7 +59,7 @@
           <span class="fa fa-cubes"></span> <%= t("sufia.toolbar.controlled_vocabs.menu") %> <span class="caret"></span>
         <% end %>
         <ul class="dropdown-menu">
-          <li><%= link_to t("sufia.toolbar.controlled_vocabs.my"), main_app.controlled_vocabs_path %></li>
+          <li><%= link_to t("sufia.toolbar.controlled_vocabs.list"), main_app.controlled_vocabs_path %></li>
           <li><%= link_to t("sufia.toolbar.controlled_vocabs.new"), main_app.new_controlled_vocab_path %></li>
         </ul>
       </li>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -36,7 +36,7 @@ en:
         batch_import: "Batch Import"
       controlled_vocabs:
         menu: "Vocabularies"
-        my: "My Controlled Vocabularies"
+        list: "Controlled Vocabularies"
         new: "New Controlled Vocabulary"
     dashboard:
       view_works:               "View Items"


### PR DESCRIPTION
Controlled vocabs aren't specific to a user so I thought having "My" was misleading.

![screen shot 2017-02-03 at 10 52 46 am](https://cloud.githubusercontent.com/assets/1202435/22597790/10ba61d4-e9ff-11e6-8ad4-85c24927c1d3.png)
