### PR TITLE
Specify Google Analytics ID via config/secrets.yml

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -32,8 +32,10 @@ Hyrax.config do |config|
   # Requires a Google Analytics id and OAuth2 keyfile.  See README for more info
   # config.analytics = false
 
-  # Google Analytics tracking ID to gather usage statistics
-  # config.google_analytics_id = 'UA-99999999-1'
+  # Specify a Google Analytics tracking ID to gather usage statistics
+  unless Rails.application.secrets[:google_analytics_id].nil?
+    config.google_analytics_id = Rails.application.secrets[:google_analytics_id]
+  end
 
   # Date you wish to start collecting Google Analytic statistics for
   # Leaving it blank will set the start date to when ever the file was uploaded by


### PR DESCRIPTION
This allows "config.google_analytics_id" to be set via a "google_analytics_id" setting placed in "config/secrets.yml".