### PR TITLE
Obtain Riiif cache_duration from config/secrets.yml

### DIFF
--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -34,4 +34,4 @@ Riiif::Image.authorization_service = IIIFAuthorizationService
 # Rails.cache. Some cache stores may not automatically purge expired content,
 # such as the default FileStore.
 # http://guides.rubyonrails.org/caching_with_rails.html#cache-stores
-Riiif::Engine.config.cache_duration = 30.days
+Riiif::Engine.config.cache_duration = Rails.application.secrets[:iiif][:cache_duration].to_i || 30.days


### PR DESCRIPTION
To avoid hard-coding the Riiif server's tile caching duration and thereby allowing us different cache times for different deployed environments (development vs. production), we obtain the duration from config/secrets.yml via the Rails.application.secrets mechanism.

Note: the duration should be an integer that represents the cache duration in seconds.