### PR TITLE
Use tags_sim instead of keyword_sim for ControlledVocab field

### DIFF
--- a/lib/importer/csv_manifest.rb
+++ b/lib/importer/csv_manifest.rb
@@ -8,7 +8,7 @@ module Importer
     validate :controlled_vocab_values
 
     def self.controlled_vocab_fields
-      ["medium", "resource_type", "keyword"]
+      ["medium", "resource_type", "tags"]
     end
 
     def self.controlled_vocab_headers

--- a/lib/importer/csv_parser.rb
+++ b/lib/importer/csv_parser.rb
@@ -45,8 +45,6 @@ module Importer
           parsedHash[:date] = val
         when 'Type'
           extract_multi_value_field(header, val, parsedHash, key = 'resource_type')
-        when 'Tags'
-          extract_multi_value_field(header, val, parsedHash, key = 'keyword')
         when 'Is Part Of'
           extract_multi_value_field(header, val, parsedHash, key = 'location')
         when 'Related URL'

--- a/lib/tasks/iawa.rake
+++ b/lib/tasks/iawa.rake
@@ -100,7 +100,7 @@ namespace :iawa do
         c_v.image_filename = name.downcase.gsub(/[\W_]/,'') + '.jpg'
       end
     end
-    keyword_names = ["11 to 20 stories", "3 to 5 stories", "6 to 10 stories", "Associations and committees",
+    tags_names = ["11 to 20 stories", "3 to 5 stories", "6 to 10 stories", "Associations and committees",
                      "Awards", "Biographical information", "Commercial and Office", "Educational and research",
                      "Faculty papers", "Healthcare", "Historic preservation", "Industrial", "Interior Design",
                      "Landscape Architecture", "Office records", "Personal papers", "Portrait",
@@ -108,9 +108,9 @@ namespace :iawa do
                      "Reference files", "Religious building spaces", "Renovations", "Residential",
                      "Residential-Housing development", "Residential-Multi-family", "Residential-Single-family",
                      "Single-family", "Single-story", "Student work", "Travel", "Two-story", "Urban Design"]
-    keyword_names.each do |name|
+    tags_names.each do |name|
       ControlledVocab.find_or_create_by(name: name) do |c_v|
-        c_v.field = 'keyword_sim'
+        c_v.field = 'tags_sim'
       end
     end
   end


### PR DESCRIPTION
**One of the ControlledVocab field name should be "tags_sim" instead of "keyword_sim".**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1572) (:star:)

# What does this Pull Request do? (:star:)
This PR fixes "keyword_sim" does not populate problem in Controlled Vocabs. We should instead use "tags_sim" to be consistent with the application.

# What's the changes? (:star:)

* Changes field from "keyword_sim" to "tags_sim" when pre-populate controlled vocabs in iawa:add_controlled_vocabs task
* Changes controlled vocab from "keyword" to "tags" in manifest file validation in batch import
* Directly use "tags" from the CSV file as metadata name in CSV parser for batch import

# How should this be tested?

* Go to Dashboard --> Configuration --> Vocabs --> List Vocabs, should list populated "tags_sim" vocabs. 
* Try to create/edit some "tag_sim" vocabs.
* Go to Dashboard --> Works --> Batch Import Items, test some Item with "Tags" values in its CSV column. (optional)

# Additional Notes:

* Branch "LIBTD-1572"
* If you do not restart your VM and please destroy the "keyword_sim" vocabs before running the iawa:add_controlled_vocabs task.

# Interested parties
Tag (@shabububu ) interested parties

(:star:) Required fields
