### PR TITLE
Fix Hyrax::CollectionType definitions pre-existence problem

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,10 +31,6 @@ module Iawa
 
     # Overrides
     config.to_prepare do
-      # TEMP Solution until LIBTD-1419 is resolved.
-      Hyrax::CollectionType.const_set('USER_COLLECTION_DEFAULT_TITLE','User Collection')
-      Hyrax::CollectionType.const_set('ADMIN_SET_DEFAULT_TITLE','Admin Set')
-
       Hyrax::HomepageController.prepend Hyrax::HomepageControllerOverride
       Hyrax::BatchUploadsController.prepend Hyrax::BatchUploadsControllerOverride
       Hyrax::CollectionsController.prepend Hyrax::CollectionsControllerOverride


### PR DESCRIPTION
**No need to re-define USER_COLLECTION_DEFAULT_TITLE and ADMIN_SET_DEFAULT_TITLE as they have been defined in Hyrax2.1.0 gem**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1419) (:star:)

* Other Relevant Links (This is related to JIRA Ticket https://webapps.es.vt.edu/jira/browse/LIBTD-1418 for compel project as they had the similar problem with errors in collection types.)

# What does this Pull Request do? (:star:)
Previously, there was a temporary fix to define collection types in config/application.rb so to set up the default collection types. Now this becomes unnecessary(duplication) as these types have already been defined in config/locales/hyrax.en.yml from hydrax2.1.0 gem.

# What's the changes? (:star:)

* Remove the definitions of default collection types in config/application.rb

# How should this be tested?

* Log in as admin user and go to dashboard --> Configuration --> Settings --> Collection Types
* Should be able to see "User Collection" and "Admin Set" collection types.
* Click on Repository Contents --> Collections --> New Collection
* Should be able to create both types of collections.
* Log in as non-admin user, go to dashboard and click on "New Collection"
* Should be able to create a "User Collection" type of collection.

# Additional Notes:

* branch LIBTD-1419

# Interested parties
Tag (@shabububu ) interested parties

(:star:) Required fields
