### PR TITLE
LIBTD-1537: Generate and use derivative jpgs from tif…

### DIFF
--- a/app/services/hyrax/file_set_derivatives_service_override.rb
+++ b/app/services/hyrax/file_set_derivatives_service_override.rb
@@ -1,0 +1,20 @@
+module Hyrax
+  module FileSetDerivativesServiceOverride
+      def create_image_derivatives(filename)
+        # We're asking for layer 0, becauase otherwise pyramidal tiffs flatten all the layers together into the thumbnail
+        Hydra::Derivatives::ImageDerivatives.create(filename,
+                                                    outputs: [{ label: :thumbnail,
+                                                                format: 'jpg',
+                                                                size: '200x150>',
+                                                                url: derivative_url('thumbnail'),
+                                                                layer: 0 }])
+        if mime_type == 'image/tiff'
+            Hydra::Derivatives::ImageDerivatives.create(filename,
+                                                        outputs: [{ label: :jpg,
+                                                                    format: 'jpg',
+                                                                    url: derivative_url('jpg'),
+                                                                    layer: 0 }])
+        end
+      end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,7 @@ module Iawa
       Hyrax::CollectionsController.prepend Hyrax::CollectionsControllerOverride
       Hyrax::Forms::CollectionForm.prepend Hyrax::Forms::CollectionFormOverride
       Hyrax::CollectionPresenter.prepend Hyrax::CollectionPresenterOverride
+      Hyrax::FileSetDerivativesService.prepend Hyrax::FileSetDerivativesServiceOverride
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,8 @@ module Iawa
       Hyrax::Forms::CollectionForm.prepend Hyrax::Forms::CollectionFormOverride
       Hyrax::CollectionPresenter.prepend Hyrax::CollectionPresenterOverride
       Hyrax::FileSetDerivativesService.prepend Hyrax::FileSetDerivativesServiceOverride
+
+      IIIFManifest::ManifestBuilder::CanvasBuilder.prepend IIIFManifest::ManifestBuilder::CanvasBuilderOverride
     end
   end
 end

--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -17,11 +17,11 @@ Riiif::Image.file_resolver.id_to_uri = lambda do |id|
     fileset_id = id.split("/").first
     logger.info "Riiif::Image.file_resolver.id_to_uri Attempting to resolve to FileSet derivative, where FileSet id = #{fileset_id}"
     path = Hyrax::DerivativePath.derivative_path_for_reference(FileSet.find(fileset_id), "jpg")
-    raise "Nil derived path" if ! File.file? path
+    raise "Path to derivative does not exist" if ! File.file? path
     logger.info "Riiif::Image.file_resolver.id_to_uri Path resolved to #{path}"
     path
   rescue
-    logger.info "Riiif::Image.file_resolver.id_to_uri Error resolving FileSet id = #{fileset_id}. Attempting to resolve to ActiveFedora uri instead."
+    logger.info "Riiif::Image.file_resolver.id_to_uri Unable to find jpg derivative for FileSet id = #{fileset_id}. Attempting to resolve using ActiveFedora uri instead."
     ActiveFedora::Base.id_to_uri(CGI.unescape(id)).tap do |url|
       logger.info "Riiif resolved #{id} to #{url}"
     end

--- a/lib/iiif_manifest/manifest_builder/canvas_builder_override.rb
+++ b/lib/iiif_manifest/manifest_builder/canvas_builder_override.rb
@@ -1,0 +1,15 @@
+module IIIFManifest
+  class ManifestBuilder
+    module CanvasBuilderOverride
+
+      private
+        def apply_record_properties
+          canvas['@id'] = path
+          # In some cases, we are using derivatives rather than the original 
+          # files, so we're removing the extension from the default canvas 
+          # label to avoid any confusion. 
+          canvas.label = Pathname(record.to_s).sub_ext ''
+        end
+    end
+  end
+end


### PR DESCRIPTION
…f for viewing in Mirador viewer

**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1537

# What does this Pull Request do?
This PR modifies the IAWA application so that when Tiff images are uploaded for a work, a derivative (akin to a thumbnail) is generated in jpg format.  Then, when a work is viewed through the Mirador viewer, the derivative jpg is used rather than the Tiff image to speed up loading time.

# What are the changes?

When creating a new work:
* A new JPG derivative is generated along with the thumbnail only if the uploaded file is a Tiff file. The derivative generation takes longer than before in this case.
* The Riiif::Image.file_resolver.id_to_uri lambda first checks to see if a derivative file exists. If it does exist, it returns the local location rather than the URI within ActiveFedora.  The download time of the local file should be faster than the download time from Fedora.

# How should this be tested?

Testing may be a bit tedious for this one. It will require creating an identical work in both the `master` branch and the `LIBTD-1537` branch.

* If you are testing in production, make sure you turn on logging for `info` messages
* Pick out a large TIFF file or two for testing. (Example: Two 100+ MB files) 
* Create a work using those large files.
* Check the logs. 

  You should see something like the following in the LIBTD-1537 branch (Derivative resolved to local file system):
  ```
  Riiif::Image.file_resolver.id_to_uri Path resolved to /var/local/hydra/iawa/tmp/derivatives/8w/32/r5/60/x-jpg.jpg
  Riiif downloaded /var/local/hydra/iawa/tmp/derivatives/8w/32/r5/60/x-jpg.jpg (9.9ms)
  ```
  You should see something like the following in the master branch (Derivative resolved to Fedora uri):
  ```
  Riiif resolved z316q156s/files/ef5d820f-82d9-4c40-8e18-cd216d144541 to http://127.0.0.1:8080/fedora/rest/prod/z3/16/q1/56/z316q156s/files/ef5d820f-82d9-4c40-8e18-cd216d144541
  Riiif downloaded http://127.0.0.1:8080/fedora/rest/prod/z3/16/q1/56/z316q156s/files/ef5d820f-82d9-4c40-8e18-cd216d144541 (906.5ms)
  ```
  For the Riiif download, the LIBTD-1537 branch should be significantly faster than the master branch.

# Additional Notes:
* I didn't see any speed increases when files were small (Example, 0-10MB total). So, these code changes will only be useful when the original TIFF file is on the large side.
* When testing, you need to make sure the derivative is generated when the work is created. You can tell if this has completed by monitoring the logs.

Example:
* What branch to be used for testing this PR? `master` and `LIBTD-1537`

# Interested parties
@tingtingjh 