### PR TITLE
LIBTD-1571: Allow for BOM UTF-8 in csv files.

### DIFF
--- a/lib/importer/csv_parser.rb
+++ b/lib/importer/csv_parser.rb
@@ -64,7 +64,7 @@ module Importer
     end
 
     def as_csv_table
-      @csv_table ||= CSV.read(file_name, headers: true)
+      @csv_table ||= CSV.read(file_name, 'r:bom|utf-8', headers: true)
     end
   end
 end


### PR DESCRIPTION
**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1571

# What does this Pull Request do?
This Pull Request allows for *.csv files with a Byte Order Marker (BOM) encoded within it to be processed correctly by our application.

# What's the changes?
(See above.) We are going to advise stakeholders to save as "CSV UTF-8" when exporting *.xlsm data to *.csv. Sometimes Excel will add a BOM to the beginning, and we need to be able to handle this. It should be a simple change to handle this properly.

# How should this be tested?
* Set up the data: In order to test this, you would need access to the *.xlsm files provided by the stakeholders. Pick one of the spreadsheets and save one of the tabs as "UTF-8 CSV". Add this to the manifest directory to the appropriate directory (e.g.,`tmp/imports`).
* Attempt to upload this file as via Batch import by going to Dashboard > Works > Batch Import Items.
* Ensure that the headers can be read appropriately. Note that, in the past, the BOM caused an error in reading the headers "Manifest file Invalid header: Identifier". You shouldn't see this error anymore.

# Additional Notes:
* What branch to be used for testing this PR? LIBTD-1571

# Interested parties
@tingtingjh 