### PR TITLE
LIBTD-1596: Add a server side file picker for the batch import manifest file

### DIFF
--- a/app/models/batch_import.rb
+++ b/app/models/batch_import.rb
@@ -17,7 +17,7 @@ class BatchImport
   def self.basepath
     if File.file?(CONFIG_FILE)
       if (config = YAML.load(File.read(CONFIG_FILE))) && config.is_a?(Hash)
-        basepath = config.deep_symbolize_keys[:basepath]
+        basepath = config[:basepath]
       end
     end
     basepath ||= File.join(Rails.root, 'tmp', 'imports')

--- a/app/views/batch_imports/_manifest_file.html.erb
+++ b/app/views/batch_imports/_manifest_file.html.erb
@@ -1,4 +1,21 @@
 <div class="form-group">
   <%= f.label :manifest_file %>
-  <%= BatchImport.basepath %><%= f.text_field :manifest_file, size: 50, class: "form_control" %>
+  <%= f.text_field :manifest_file, size: 50, class: "form_control" %>
+  <button type="button" data-toggle="browse-everything" data-route="/browse"
+	  data-target="#myForm" class="btn btn-md btn-success" id="browse-manifest">Browse</button>
+  <script>
+    $(document).ready(function() {
+      $('#browse-manifest').browseEverything().done(function(data) {
+        // TODO: Find a better way to limit only one file at a time.
+        if (data.length != 1) {
+          alert("Please specify a single manifest file.");
+        } else {
+          filePrefixRe = /^file\:\/\/<%= BatchImport.basepath.gsub("/", "\\\/") %>\//i;
+          newFile =  data[0].url.replace(filePrefixRe,"")
+          $('#batch_import_manifest_file').val( newFile );
+        }
+      })
+    });
+  </script>
+  
 </div>

--- a/app/views/browse_everything/_files.html.erb
+++ b/app/views/browse_everything/_files.html.erb
@@ -1,0 +1,72 @@
+<%# Modified from browse-everything Gem: Removed the select all option for directories %>
+
+  <table id="file-list" role="grid" tabindex="-1" title="Choose files to upload from the table below" aria-live="polite">
+    <thead>
+      <tr role="row" tabindex="-1">
+        <th role="columnheader">Name</th>
+	<%# IAWA begin: Remove select all option for directories %>
+        <th role="columnheader">Select</th>
+	<%# IAWA begin: Remove select all option for directories %>
+        <th role="columnheader">Size</th>
+        <th role="columnheader">Kind</th>
+        <th role="columnheader">Modified</th>
+      </tr>
+    </thead>
+    <% provider_contents.each_with_index do |file, index| %>
+      <% path = browse_everything_engine.contents_path(provider_name, file.id) %>
+      <% parent = params[:parent] %>
+      <% if file.container? || provider.config[:max_upload_file_size].blank? %>
+         <% disabled = false %>
+      <% else %>
+         <% max_size = provider.config[:max_upload_file_size].to_i %>
+         <% disabled = file.size > max_size %>
+      <% end %>
+
+      <tr role="row"
+          tabindex="-1"
+          data-ev-location="<%= file.location %>"
+          data-tt-id="<%= path %>"
+          data-tt-parent-id="<%= parent %>"
+          data-tt-branch="<%= file.container? ? 'true' : 'false' %>">
+
+        <td role="gridcell" title="<%= file.name %>" class="<%=file.container? ? 'ev-container' : 'ev-file'%> ev-file-name">
+          <% if disabled %>
+            <span title="<%= t('browse_everything.size_disabled', max_size: number_to_human_size(max_size)) %>"
+                  class="<%=file.container? ? 'folder' : 'file'%>" aria-hidden="true">
+              <%= file.name %>
+            </span>
+            <span class="sr-only"><%= file.container? ? ', folder' : ', file' %> </span>
+          <% else %>
+            <%= link_to browse_everything_engine.contents_path(provider_name, file.id), class: 'ev-link' do %>
+              <span class="<%=file.container? ? 'folder' : 'file'%>" aria-hidden="true"/>
+              <%= file.name %>
+              <span class="sr-only"><%= file.container? ? ', folder' : ', file' %> </span>
+            <% end %>
+          <% end %>
+        </td>
+        <% if file.container? %>
+          <td role="gridcell" class="ev-directory-select">
+	    <%# IAWA begin: Remove select all option %>
+            <%= check_box_tag(:select_all, "0", false, class: "ev-select-all hidden") %>
+	    <%# IAWA end: Remove select all option %>
+          </td>
+        <% else %>
+          <td role="gridcell" class="ev-file-select">
+            <%= check_box_tag(file.id.to_s.parameterize, "0", false, class: "ev-select-file") %>
+          </td>
+        <% end %>
+
+        <td role="gridcell" class="ev-file-size">
+          <%= number_to_human_size(file.size).sub(/Bytes/,'bytes') %>
+        </td>
+
+        <td role="gridcell" class="ev-file-kind">
+          <%= file.type %>
+        </td>
+
+        <td role="gridcell" class="ev-file-date">
+          <%= file.mtime.strftime('%F %R') %>
+        </td>
+    </tr>
+  <% end %>
+</table>

--- a/config/batch_import.yml
+++ b/config/batch_import.yml
@@ -1,1 +1,1 @@
-basepath: /var/local/hydra/iawa/tmp/imports
+basepath: <%= Rails.application.secrets[:batch_import_basepath] %>

--- a/config/browse_everything_providers.yml
+++ b/config/browse_everything_providers.yml
@@ -1,0 +1,23 @@
+#
+# To make browse-everything aware of a provider, uncomment the info for that provider and add your API key information.
+# The file_system provider can be a path to any directory on the server where your application is running.
+#
+file_system:
+  home: <%= Rails.application.secrets[:batch_import_basepath] %>
+# dropbox:
+#   app_key: YOUR_DROPBOX_APP_KEY
+#   app_secret: YOUR_DROPBOX_APP_SECRET
+# box:
+#   client_id: YOUR_BOX_CLIENT_ID
+#   client_secret: YOUR_BOX_CLIENT_SECRET
+# google_drive:
+#   client_id: YOUR_GOOGLE_API_CLIENT_ID
+#   client_secret: YOUR_GOOGLE_API_CLIENT_SECRET
+# s3:
+#   bucket: YOUR_AWS_S3_BUCKET
+#   response_type: signed_url # set to :public_url for public urls or :s3_uri for an s3://BUCKET/KEY uri
+#   expires_in: 14400 # for signed_url response_type, number of seconds url will be valid for.
+#   app_key: YOUR_AWS_S3_KEY       # :app_key, :app_secret, and :region can be specified
+#   app_secret: YOUR_AWS_S3_SECRET # explicitly here, or left out to use system-configured
+#   region: YOUR_AWS_S3_REGION     # defaults.
+#   See https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,12 @@
 Rails.application.routes.draw do
+
+  browse_everything_constraint = lambda do |request|
+    request.env['warden'].authenticate? && request.env['warden'].user.admin?
+  end
+  constraints browse_everything_constraint do
+    mount BrowseEverything::Engine => '/browse'
+  end
+
   require 'sidekiq/web'
   mount Sidekiq::Web => '/sidekiq'
   mount Riiif::Engine => '/image-service', as: 'riiif'


### PR DESCRIPTION
**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1596

# What does this Pull Request do?
This PR adds a server side file picker for selecting the batch import manifest.

# What are the changes?
* Uses a lightly customized BrowseEverything gem as a server side file picker for selecting the batch upload manifest file.
* Because the batch import and the BrowseEverything functionality depend on YAML configuration files that point to same directory, the related config files have been modified to set the directory values from the same `secrets.yml` setting `batch_import_basepath`
* Note: This PR does not modify the related batch import directory folder.

# How should this be tested?

* This PR is dependent on the the following PR to InstallScripts: https://github.com/VTUL/InstallScripts/pull/180. Please wait until this one has been merged first before using InstallScripts to build the application.
* Use InstallScripts to build the application. Make sure to use the default `batch_import_basepath` in the `example_site_secrets.yml`. Also, make sure you include the `user_list.txt` and `admin_list.txt` so that you can log in as administrator once the VM is running.
* Once the VM is running, use `vagrant ssh` to add any number of directories and files under the `batch_import_basepath` directory (`/var/local/hydra/iawa/tmp/imports` by default). Set permissions to `555` for directories and `444` for files.
* Go to the Dashboard. Click on Works on the left. Click on the Batch Import Items button.
* On the batch Import Items page, click on the Browse button. You should be given options to choose from the directories and files that you added. 
* Try selecting a file. Once you submit, the corresponding text field should be updated to reflect the file you've chosen. If you cancel, the file should be unchanged. If you attempt to select more than one file, you should get an error.
* The BrowseEverything generator by default creates a `/browse` endpoint in the Routes that can be viewed by everyone. Test to make sure that you cannot access this endpoint when you are not logged in as an administrator. (You should be able to just log out, but it would be good to also test being logged in as a non-admin user.)

# Additional Notes:
* What branch to be used for testing this PR? LIBTD-1596
* It would have been good to make modifications to also select the files directory folder, but that is proving a little more difficult. We'll have to push that modification to another ticket/PR.

# Interested parties
@tingtingjh @whunter 