### PR TITLE
Ran 'bundle lock --update=rubyzip' after getting Github security alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -680,7 +680,7 @@ GEM
       oauth2
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     samvera-nesting_indexer (2.0.0)
       dry-equalizer
     sass (3.5.7)


### PR DESCRIPTION
**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1632

# What does this Pull Request do? (:star:)
This updates the `rubyzip` gem in `Gemfile.lock` to address the recent Github Security Vulnerability alert.

# What are the changes? 
(see above)

# How should this be tested?
* Ensure that the application builds appropriately with InstallScripts
* Try out various functionality (create a work, collection) and make sure that nothing is impaired.

# Additional Notes:
* What branch to be used for testing this PR? 20181109_rubyzip_security_update
* This security warning came soon after the last update was merged (#107). Otherwise, it would have been addressed with the last PR.

# Interested parties
@VTUL/dld-dev
