### PR TITLE
LIBTD-1540: Change non-graylog logging to be size-based, rather than …

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -94,8 +95,10 @@ Rails.application.configure do
       { "params" => params }
     end
   else
-    # Create a standard logger that writes to log/production.log and rotates them daily
-    config.logger = Logger.new(Rails.root.join('log', "#{Rails.env}.log"), "daily")
+    # Create a standard logger that writes to log/production.log and rotates them.
+    # This ages the logfile once it reaches a certain size. Leave 12 “old” log files where 
+    # each file is about 10485760 bytes. See LIBTD-1540 for more information.
+    config.logger = Logger.new(Rails.root.join('log', "#{Rails.env}.log"), 12, 10485760)
     config.log_level = :warn
   end
   # Do not dump schema after migrations.


### PR DESCRIPTION
…daily.

**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1540

# What does this Pull Request do? (:star:)
This PR changes non-graylog logging to be size-based rather than generated daily when deployed to a production environment.

# What's the changes?
(see above)

# How should this be tested?

Using VTUL/InstallScripts, configure your `ansible/site_secrets.yml` to be the following:

```
project_name: 'iawa'
project_git_identifier: 'LIBTD-1540'
project_app_env: 'production'
project_secret_key_base: '<some key here>'
graylog_enable: false
```

Ensure that the VM's `/var/local/hydra/iawa/log/production.log` is growing appropriately.  For the purposes of this PR, the tester can modify the `/var/local/hydra/iawa/config/environments/production.rb` to age the logfiles at a smaller size. In other words, change the `10485760` to be smaller a number below:

```
config.logger = Logger.new(Rails.root.join('log', "#{Rails.env}.log"), 12, 10485760)
```

# Additional Notes:
* What branch to be used for testing this PR? LIBTD-1540
* This affects production deployments that do not use Graylog.

# Interested parties
@VTUL/dld-dev 
