### PR TITLE
LIBTD-1654: Simplifying homepage; Removing Browse Collections/Items b…

### DIFF
--- a/app/views/hyrax/homepage/_browse_items_by_tags.html.erb
+++ b/app/views/hyrax/homepage/_browse_items_by_tags.html.erb
@@ -1,4 +1,3 @@
-<h2>Browse Items by Tags</h2>
 <div id="cloud-tag-container"></div>
 <div id="tag-panel" class="panel-group">
   <%= render_facet_partials ["tags_sim"], partial: 'facet_limit' %>

--- a/app/views/hyrax/homepage/_home_content.html.erb
+++ b/app/views/hyrax/homepage/_home_content.html.erb
@@ -1,22 +1,7 @@
 <h3>A visual exhibit of selected items from the International Archive of Women in Architecture, a joint partnership between the College of Architecture and Urban Studies and the University Libraries at Virginia Tech</h3>
-<div class="col-xs-12 col-sm-6">
-  <div>
-    <%= render partial: 'browse_collections_by_architect' %>
-  </div>
-</div><!-- /.col-xs-6 -->
-<div class="col-xs-12 col-sm-6">
+<div class="col-xs-12 col-sm-12">
   <div>
     <%= render partial: 'browse_items_by_tags' %>
-  </div>
-</div>
-<div class="col-xs-12 col-sm-6">
-  <div>
-    <%= render partial: 'browse_items_by_medium' %>
-  </div>
-</div><!-- /.col-xs-6 -->
-<div class="col-xs-12 col-sm-6">
-  <div>
-    <%= render partial: 'browse_items_by_type' %>
   </div>
 </div>
 


### PR DESCRIPTION
…y Medium/Items by Type sections; Keeping Tag cloud

**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1654

# What does this Pull Request do?
This PR simplifies the IAWA homepage. The PR removes the Browse Collections, Browse Items by Medium, and Browse Items by Type sections. The PR keeps the Tag cloud, but removes its header.

# What's the changes?
(See above.)

# How should this be tested?

A description of what steps someone could take to:
* Use VTUL/InstallScripts to build this application in production.
* Add various items (preferably more than 10), with varying `Tag` values;
* Visit the IAWA homepage and verify the following:
  * The Browse Collections section is no longer there
  * The Browse Items by Medium section is no longer there
  * The Browse Items by Type section is no longer there
  * The Tag cloud is there, but the header Browse by Items by Tags is no longer there.

# Additional Notes:
* What branch to be used for testing this PR? LIBTD-1654

# Interested parties
Tag @VTUL/dld-dev 
