### PR TITLE
LIBTD-1665: CreateDerivativesJob retry delay + mod to allow handling of empty csv lines

### DIFF
--- a/app/jobs/create_derivatives_job_override.rb
+++ b/app/jobs/create_derivatives_job_override.rb
@@ -1,0 +1,13 @@
+# Attempting to override Hyrax Gem 2.1.0
+#   app/jobs/create_derivative_job.rb
+#
+# LIBTD-1665: Attempting to slow down the retry scheduling
+# for derivatives that take longer to create.
+
+module CreateDerivativesJobOverride
+  def self.prepended(base)
+    base.rescue_from(MiniMagick::Error) do
+      retry_job wait: 5.minutes, queue: Hyrax.config.ingest_queue_name
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,6 +42,8 @@ module Iawa
       Hyrax::CollectionPresenter.prepend Hyrax::CollectionPresenterOverride
       Hyrax::FileSetDerivativesService.prepend Hyrax::FileSetDerivativesServiceOverride
 
+      CreateDerivativesJob.prepend CreateDerivativesJobOverride
+
       IIIFManifest::ManifestBuilder::CanvasBuilder.prepend IIIFManifest::ManifestBuilder::CanvasBuilderOverride
     end
   end

--- a/lib/importer/csv_importer.rb
+++ b/lib/importer/csv_importer.rb
@@ -18,6 +18,11 @@ module Importer
       files_dir_array = Dir.glob(files_directory + "/**/Access")
       parser.each do |attributes|
         attrs = attributes.merge(deposit_attributes).merge(visibility_attributes)
+
+        if ! attrs[:identifier].present?
+          next
+        end
+
         obj_id = attrs[:identifier].first
         obj_file_dir = files_dir_array.detect { |f_d| f_d.end_with?(obj_id + "/Access") }
         parent_collection_id = collection_id


### PR DESCRIPTION
**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1665

# What does this Pull Request do?
In order to handle batch imports with larger files (2-3 GB), we are modifying the retry delay for the CreateDerivativesJob and changing how we process csv lines with no identifier is present (which in our case were created when unnecessary lines were activated in xlsm files and converted to csvs).

# What are the changes?

* We are modifying the retry time for the CreateDerivativesJob to be 5 minutes.
* We are skipping lines where no identifier is present. Often when converting from xlsm file to csv, extra blank lines are accidentally included. Without skipping these lines, the batch import process will result in error and push the job back into the retry queue, which is what we want to avoid.

# How should this be tested?

* Either work with @soumikgh to test in PPRD or test locally in production. (It may be easier to test in pprd because copying over the files from libvault is time consuming. Also, pprd is currently set up with 32 GB RAM and faster disk so that testing may be quicker and easier. It would add work for Soumik, though.)
* Use the Webb box43 data referenced in the JIRA ticket and ensure batch upload can eventually be completed successfully. Make sure only one of each image (5 total) is associated with the work (and not 10, 15, 20, etc.)
* Monitor sidekiq and make sure that any CreateDerivativesJob retries are now scheduled after 5 minute intervals.

# Additional Notes:
* What branch to be used for testing this PR? `LIBTD-1665`
* Without these changes, the BatchUploadJob would be pushed in the retry queue when there were empty lines present due to an error `NoMethodError: undefined method `first' for nil:NilClass`. As a result, multiple versions of the same image would be added to a work incorrectly. If this change works, then you shouldn't have that problem anymore.

# Interested parties
@tingtingjh @soumikgh 

