### PR TITLE
LIBTD-1623: Changing derivatives_path to be outside of the applicatio…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,8 +51,10 @@ config/application.yml
 # Ignore photos for carousel, owned/managed by UniRel.
 /app/assets/images/carousel
 
-
 /node_modules
 /yarn-error.log
 
 .byebug_history
+
+# Derivatives Directory
+/derivatives

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -122,7 +122,7 @@ Hyrax.config do |config|
 
   # Location on local file system where derivatives will be stored
   # If you use a multi-server architecture, this MUST be a shared volume
-  # config.derivatives_path = Rails.root.join('tmp', 'derivatives')
+  config.derivatives_path = Rails.root.join('derivatives')
 
   # Should schema.org microdata be displayed?
   # config.display_microdata = true


### PR DESCRIPTION
…n tmp dir

**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1623

# What does this Pull Request do?
This PR moves the `derivatives` directory outside the application's `tmp` directory.

# What's the changes? (:star:)
See above.

# How should this be tested?

NOTE: This PR is dependent on the InstallScripts PR: https://github.com/VTUL/InstallScripts/pull/184

* Perform a batch import in your local production build. Also, create a new work with an image associated with it.
* Check to make sure that thumbnails and viewers are correctly displaying these images.
* Check that derivatives are being stored with the application's `derivatives` directory. 
* Check that the `tmp/derivatives` is empty.

# Additional Notes:
* What branch to be used for testing this PR? LIBTD-1623

# Interested parties
@tingtingjh 