### PR TITLE
LIBTD-1692: Work-around rake task to update solr index for Collections

### DIFF
--- a/lib/tasks/iawa.rake
+++ b/lib/tasks/iawa.rake
@@ -151,4 +151,15 @@ namespace :iawa do
     end
   end
 
+  # usage: iawa:reindex_collections
+  desc 'Reindex Collections'
+  task reindex_collections: :environment do
+    # NOTE: This is a less than ideal work-around for LIBTD-1692,
+    #       where the collection size may not be updated correctly
+    #       after batch imports.
+    #       Running this command periodically will update existing
+    #       collections, but will need to be run after future batch
+    #       imports.
+    Collection.all.each { |collection| collection.update_index }
+  end
 end


### PR DESCRIPTION
**JIRA Ticket**: https://webapps.es.vt.edu/jira/browse/LIBTD-1692

# What does this Pull Request do?
This Pull Request adds a rake task to update the Solr index of all existing Collections within the application.

# What are the changes?
This is a less than ideal work-around for LIBTD-1692, where the collection size may not be updated correctly after batch imports.

We hope to schedule this rake task to run at regular intervals or when necessary until a better solution can be found.

# How should this be tested?
* Use InstallScripts to build the application using the `LIBTD-1692-workaround` branch.
* Log into the application as an admin user, and navigate to your Dashboard > Works page. Select `Batch Import Items`.
* Reproduce a case where a batch upload produces a Collection that the application shows incorrectly as 0 bytes. 
  * Put your batch import csv on your VM under the directory `/var/local/hydra/iawa/tmp/imports/`. One potential batch upload csv file is the following: https://webapps.es.vt.edu/jira/secure/attachment/184461/IAWAGrant_RudoffLorraine_Ms1990_025_B1_Fitzsimmons_CollectionSizeNG.csv
  * If using the csv above, put at least one image in the following directory on your VM: `/var/local/hydra/iawa/tmp/imports/Ms1990_025_Rudoff/Ms1990_025_Box1/Ms1990_025_Folder1/Ms1990_025_Per_Eph_B001_F001_001/Access/`
  * Finally, if using the csv above, use `Ms1990_025_Rudoff/Ms1990_025_Box1`  for your Files directory.
  * Verify that resulting Collection size for the furthest nested Collection is 0 bytes.
* To correct the Collection size, run the following as the `railsapps` user on your VM: `bundle exec rails iawa:reindex_collections`
* Reload the Collection view and verify that the size has been updated to the appropriate non-0 size.

# Interested parties
@tingtingjh 